### PR TITLE
Add allNodeKeysSortedByLocation method

### DIFF
--- a/Lexical/Helper/RangeHelpers.swift
+++ b/Lexical/Helper/RangeHelpers.swift
@@ -93,3 +93,26 @@ func searchInNode<Payload: Equatable>(node: Node, comparison: (Node) -> (RangeSe
     ranges.append((range, currentPayloadResolved))
   }
 }
+
+public func allNodeKeysSortedByLocation() -> [NodeKey] {
+  guard let editor = getActiveEditor() else {
+    return []
+  }
+  return editor.rangeCache.map { $0 }
+    .sorted { a, b in
+      // return true if a<b
+      let itemA = a.value
+      let itemB = b.value
+      if itemA.location < itemB.location {
+        return true
+      }
+      if itemA.location > itemB.location {
+        return false
+      }
+      // we have the same location
+      return itemA.range.length > itemB.range.length
+    }
+    .map { element in
+      element.key
+    }
+}

--- a/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdownUtils.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdownUtils.swift
@@ -10,13 +10,13 @@ import Lexical
 import Markdown
 
 extension Array where Element == Node {
-  func exportAsInlineMarkdown(indentation: Int) -> [Markdown.InlineMarkup] {
+  public func exportAsInlineMarkdown(indentation: Int) -> [Markdown.InlineMarkup] {
     compactMap {
       try? ($0 as? NodeMarkdownInlineSupport)?.exportInlineMarkdown(indentation: indentation)
     }
   }
 
-  func exportAsBlockMarkdown() -> [Markdown.BlockMarkup] {
+  public func exportAsBlockMarkdown() -> [Markdown.BlockMarkup] {
     compactMap {
       try? ($0 as? NodeMarkdownBlockSupport)?.exportBlockMarkdown()
     }


### PR DESCRIPTION
Summary:
A new Lexical function allNodeKeysSortedByLocation(), which uses the Range Cache information. We will need for this in an external integration, to iterate through all nodes in order.

Re-implemented from D53178261 as original diff is too old

Differential Revision:
D56883689

Privacy Context Container: L22797

fbshipit-source-id: aad2925745efbbc7fb63dddece1f70d97a6ef03e